### PR TITLE
过滤空级目录

### DIFF
--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -19,7 +19,7 @@ Route::get('/', function () {
 
 // 插件模块(登录验证需要插件自己调用auth中间件)
 $path = app('request')->path();
-$route = explode('/', $path);
+$route = array_values(array_filter(explode('/', $path)));
 
 if (count($route) >= 2) {
     $group = $route[0];


### PR DESCRIPTION
当独立域名访问时explode('/', '/')会返回包含两个空元素的数组。